### PR TITLE
Feature/stopwords ratio feature extractor 17

### DIFF
--- a/src/authorship_attribution/_internal/features/average/words/stopwords_ratio.py
+++ b/src/authorship_attribution/_internal/features/average/words/stopwords_ratio.py
@@ -1,0 +1,13 @@
+from authorship_attribution._internal.features.base.base import Feature
+
+
+class StopwordsRatioFeature(Feature):
+    def __init__(self, stopwords_count: int, total_word_count: int) -> None:
+        super().__init__()
+        self.stopwords_count = stopwords_count
+        self.total_word_count = total_word_count
+
+    def stopwords_ratio(self) -> float:
+        if self.total_word_count == 0:
+            return 0.0
+        return self.stopwords_count / self.total_word_count

--- a/src/authorship_attribution/_internal/features/extractors/average/words/stopwords_ratio.py
+++ b/src/authorship_attribution/_internal/features/extractors/average/words/stopwords_ratio.py
@@ -1,0 +1,35 @@
+from typing import override
+from nltk.corpus import stopwords
+
+from authorship_attribution._internal.features.extractors.base.words import (
+    WordFeatureExtractor,
+)
+from authorship_attribution._internal.features.average.words.stopwords_ratio import (
+    StopwordsRatioFeature,
+)
+from authorship_attribution._internal.types.aliases import Text
+
+ENGLISH_STOPWORDS = set(stopwords.words("english"))
+
+
+class StopwordsRatioFeatureExtractor(WordFeatureExtractor):
+    def __init__(self, text: Text) -> None:
+        super().__init__(text)
+
+    def stopwords_count(self) -> int:
+        count = 0
+        for word in self.words:
+            if word.lower() in ENGLISH_STOPWORDS:
+                count += 1
+        return count
+
+    def total_word_count(self) -> int:
+        return len(self.words)
+
+    @override
+    def feature(self) -> StopwordsRatioFeature:
+        sw_count: int = self.stopwords_count()
+        total_count: int = self.total_word_count()
+        return StopwordsRatioFeature(
+            stopwords_count=sw_count, total_word_count=total_count
+        )

--- a/tests/features/average/words/test_stopwords_ratio.py
+++ b/tests/features/average/words/test_stopwords_ratio.py
@@ -1,0 +1,81 @@
+from typing import Literal
+from pytest import fixture, approx
+
+from authorship_attribution._internal.features.average.words.stopwords_ratio import (
+    StopwordsRatioFeature,
+)
+from authorship_attribution._internal.types.aliases import Json
+
+
+@fixture
+def name() -> Literal["stopwords_ratio_feature"]:
+    return "stopwords_ratio_feature"
+
+
+@fixture
+def file_name() -> Literal["stopwords_ratio_feature.json"]:
+    return "stopwords_ratio_feature.json"
+
+
+@fixture
+def stopwords_count_val() -> int:
+    return 25
+
+
+@fixture
+def total_word_count_val() -> int:
+    return 100
+
+
+@fixture
+def json_data(stopwords_count_val: int, total_word_count_val: int) -> Json:
+    return {
+        "stopwords_count": stopwords_count_val,
+        "total_word_count": total_word_count_val,
+    }
+
+
+@fixture
+def stopwords_ratio_feature_instance(
+    stopwords_count_val: int, total_word_count_val: int
+) -> StopwordsRatioFeature:
+    return StopwordsRatioFeature(stopwords_count_val, total_word_count_val)
+
+
+def test_name(name: Literal["stopwords_ratio_feature"]) -> None:
+    assert StopwordsRatioFeature.name() == name
+
+
+def test_file_name(file_name: Literal["stopwords_ratio_feature.json"]) -> None:
+    assert StopwordsRatioFeature.file_name() == file_name
+
+
+def test_to_json(
+    stopwords_ratio_feature_instance: StopwordsRatioFeature, json_data: Json
+) -> None:
+    assert stopwords_ratio_feature_instance.to_json() == json_data
+
+
+def test_from_json(
+    json_data: Json, stopwords_count_val: int, total_word_count_val: int
+) -> None:
+    feature = StopwordsRatioFeature.from_json(json_data)
+    assert isinstance(feature, StopwordsRatioFeature)
+    assert feature.stopwords_count == stopwords_count_val
+    assert feature.total_word_count == total_word_count_val
+
+
+def test_ratio_calculation(
+    stopwords_ratio_feature_instance: StopwordsRatioFeature,
+) -> None:
+    assert stopwords_ratio_feature_instance.stopwords_ratio() == approx(0.25)
+
+
+def test_ratio_calculation_zero_total_words() -> None:
+    feature_zero_all = StopwordsRatioFeature(stopwords_count=0, total_word_count=0)
+    assert feature_zero_all.stopwords_ratio() == approx(0.0)
+
+    feature_stopwords_no_total = StopwordsRatioFeature(
+        stopwords_count=5, total_word_count=0
+    )
+    assert feature_stopwords_no_total.stopwords_ratio() == approx(0.0)

--- a/tests/features/extractors/average/words/test_stopwords_ratio.py
+++ b/tests/features/extractors/average/words/test_stopwords_ratio.py
@@ -1,0 +1,99 @@
+from pytest import fixture, approx
+
+from authorship_attribution._internal.features.extractors.average.words.stopwords_ratio import (
+    StopwordsRatioFeatureExtractor,
+)
+from authorship_attribution._internal.types.aliases import Text
+
+
+@fixture
+def text_with_stopwords() -> Text:
+    return "This is a sample text and it contains some of the stopwords."
+
+
+@fixture
+def text_no_stopwords() -> Text:
+    return "MyCorp lexicographers craft elegant prose."
+
+
+@fixture
+def text_empty() -> Text:
+    return ""
+
+
+@fixture
+def extractor_with_stopwords(
+    text_with_stopwords: Text,
+) -> StopwordsRatioFeatureExtractor:
+    return StopwordsRatioFeatureExtractor(text_with_stopwords)
+
+
+@fixture
+def extractor_no_stopwords(text_no_stopwords: Text) -> StopwordsRatioFeatureExtractor:
+    return StopwordsRatioFeatureExtractor(text_no_stopwords)
+
+
+@fixture
+def extractor_empty(text_empty: Text) -> StopwordsRatioFeatureExtractor:
+    return StopwordsRatioFeatureExtractor(text_empty)
+
+
+def test_stopwords_count_with_stopwords(
+    extractor_with_stopwords: StopwordsRatioFeatureExtractor,
+) -> None:
+    assert extractor_with_stopwords.stopwords_count() == 8
+
+
+def test_total_word_count_with_stopwords(
+    extractor_with_stopwords: StopwordsRatioFeatureExtractor,
+) -> None:
+    assert extractor_with_stopwords.total_word_count() == 13
+
+
+def test_stopwords_count_no_stopwords(
+    extractor_no_stopwords: StopwordsRatioFeatureExtractor,
+) -> None:
+    assert extractor_no_stopwords.stopwords_count() == 0
+
+
+def test_total_word_count_no_stopwords(
+    extractor_no_stopwords: StopwordsRatioFeatureExtractor,
+) -> None:
+    assert extractor_no_stopwords.total_word_count() == 6
+
+
+def test_stopwords_count_empty(extractor_empty: StopwordsRatioFeatureExtractor) -> None:
+    assert extractor_empty.stopwords_count() == 0
+
+
+def test_total_word_count_empty(
+    extractor_empty: StopwordsRatioFeatureExtractor,
+) -> None:
+    assert extractor_empty.total_word_count() == 0
+
+
+def test_feature_extraction_with_stopwords(
+    extractor_with_stopwords: StopwordsRatioFeatureExtractor,
+) -> None:
+    feature = extractor_with_stopwords.feature()
+    assert feature.stopwords_count == 8
+    assert feature.total_word_count == 13
+    assert feature.stopwords_ratio() == approx(8 / 13)
+
+
+def test_feature_extraction_no_stopwords(
+    extractor_no_stopwords: StopwordsRatioFeatureExtractor,
+) -> None:
+    feature = extractor_no_stopwords.feature()
+    assert feature.stopwords_count == 0
+    assert feature.total_word_count == 6
+    assert feature.stopwords_ratio() == approx(0.0)
+
+
+def test_feature_extraction_empty(
+    extractor_empty: StopwordsRatioFeatureExtractor,
+) -> None:
+    feature = extractor_empty.feature()
+    assert feature.stopwords_count == 0
+    assert feature.total_word_count == 0
+    assert feature.stopwords_ratio() == approx(0.0)


### PR DESCRIPTION
## How to calculate
   
1. Have a predefined list of stopwords (NLTK).
2. Count how many words in the text are on this stopword list.
3. Divide this count by the total number of words in the text.

## Todo

- [x] Implement `StopwordsRatioFeature` class.
- [x] Implement `StopwordsRatioFeatureExtractor` class.
- [x] Implement `StopwordsRatioFeatureFeature` unit tests.
- [x] Implement `StopwordsRatioFeatureExtractor` unit tests.
