### PR TITLE
Feature: part of speech tag frequencies extractor #28

### DIFF
--- a/src/authorship_attribution/_internal/features/average/pos_tag_frequencies.py
+++ b/src/authorship_attribution/_internal/features/average/pos_tag_frequencies.py
@@ -1,0 +1,23 @@
+from typing import Counter
+from authorship_attribution._internal.features.base.base import Feature
+
+
+class PartOfSpeechTagFrequenciesFeature(Feature):
+    pass
+
+    def __init__(
+        self,
+        part_of_speach_tags_counts: Counter[str],
+        total_part_of_speach_tags_count: int,
+    ) -> None:
+        super().__init__()
+        self.part_of_speach_tags_counts = part_of_speach_tags_counts
+        self.total_part_of_speach_tags_count = total_part_of_speach_tags_count
+
+    def part_of_speach_tag_frequencies(self) -> dict[str, float]:
+        if self.total_part_of_speach_tags_count == 0:
+            return dict[str, float]()
+        return {
+            tag: count / self.total_part_of_speach_tags_count
+            for tag, count in self.part_of_speach_tags_counts.items()
+        }

--- a/src/authorship_attribution/_internal/features/extractors/average/pos_tag_frequencies.py
+++ b/src/authorship_attribution/_internal/features/extractors/average/pos_tag_frequencies.py
@@ -1,0 +1,24 @@
+from collections import Counter
+from authorship_attribution._internal.features.average.pos_tag_frequencies import PartOfSpeechTagFrequenciesFeature
+from authorship_attribution._internal.features.extractors.base.pos_tags import (
+    PartOfSpeechTagFeatureExtractor,
+)
+from authorship_attribution._internal.types.aliases import Text
+
+
+class PartOfSpeechTagFrequenciesFeatureExtractor(PartOfSpeechTagFeatureExtractor):
+    def __init__(self, text: Text) -> None:
+        super().__init__(text)
+
+    def part_of_speach_tags_counts(self) -> Counter[str]:
+        return Counter[str](self.part_of_speech_tags)
+
+    def total_part_of_speach_tags_count(self) -> int:
+        return len(self.part_of_speech_tags)
+
+    def feature(self) -> PartOfSpeechTagFrequenciesFeature:
+        part_of_speach_tags_counts: Counter[str] = self.part_of_speach_tags_counts()
+        total_part_of_speach_tags_count: int = self.total_part_of_speach_tags_count()
+        return PartOfSpeechTagFrequenciesFeature(
+            part_of_speach_tags_counts, total_part_of_speach_tags_count
+        )

--- a/src/authorship_attribution/_internal/features/extractors/average/pos_tag_frequencies.py
+++ b/src/authorship_attribution/_internal/features/extractors/average/pos_tag_frequencies.py
@@ -1,5 +1,7 @@
 from collections import Counter
-from authorship_attribution._internal.features.average.pos_tag_frequencies import PartOfSpeechTagFrequenciesFeature
+from authorship_attribution._internal.features.average.pos_tag_frequencies import (
+    PartOfSpeechTagFrequenciesFeature,
+)
 from authorship_attribution._internal.features.extractors.base.pos_tags import (
     PartOfSpeechTagFeatureExtractor,
 )

--- a/src/authorship_attribution/_internal/features/extractors/base/pos_tags.py
+++ b/src/authorship_attribution/_internal/features/extractors/base/pos_tags.py
@@ -1,0 +1,11 @@
+import nltk
+from authorship_attribution._internal.features.extractors.base.words import (
+    WordFeatureExtractor,
+)
+from authorship_attribution._internal.types.aliases import Text
+
+
+class PartOfSpeechTagFeatureExtractor(WordFeatureExtractor):
+    def __init__(self, text: Text) -> None:
+        super().__init__(text)
+        self.part_of_speech_tags = [tag for _, tag in nltk.pos_tag(self.words)]

--- a/tests/features/average/test_pos_tag_frequencies.py
+++ b/tests/features/average/test_pos_tag_frequencies.py
@@ -1,0 +1,73 @@
+from collections import Counter
+from typing import Literal
+from pytest import fixture
+
+from authorship_attribution._internal.features.average.pos_tag_frequencies import (
+    PartOfSpeechTagFrequenciesFeature,
+)
+from authorship_attribution._internal.types.aliases import Json
+
+
+@fixture
+def name() -> Literal["part_of_speech_tag_frequencies_feature"]:
+    return "part_of_speech_tag_frequencies_feature"
+
+
+@fixture
+def file_name() -> Literal["part_of_speech_tag_frequencies_feature.json"]:
+    return "part_of_speech_tag_frequencies_feature.json"
+
+
+@fixture
+def part_of_speach_tags_counts() -> Counter[str]:
+    return Counter[str]({"NN": 3, "VB": 5, "JJ": 2})
+
+
+@fixture
+def total_part_of_speach_tags_count() -> int:
+    return 10
+
+
+@fixture
+def json(
+    part_of_speach_tags_counts: Counter[str], total_part_of_speach_tags_count: int
+) -> Json:
+    return {
+        "part_of_speach_tags_counts": part_of_speach_tags_counts,
+        "total_part_of_speach_tags_count": total_part_of_speach_tags_count,
+    }
+
+
+@fixture
+def feature(
+    part_of_speach_tags_counts: Counter[str], total_part_of_speach_tags_count: int
+) -> PartOfSpeechTagFrequenciesFeature:
+    return PartOfSpeechTagFrequenciesFeature(
+        part_of_speach_tags_counts,
+        total_part_of_speach_tags_count,
+    )
+
+
+def test_name(name: Literal["part_of_speech_tag_frequencies_feature"]) -> None:
+    assert PartOfSpeechTagFrequenciesFeature.name() == name
+
+
+def test_file_name(
+    file_name: Literal["part_of_speech_tag_frequencies_feature.json"],
+) -> None:
+    assert PartOfSpeechTagFrequenciesFeature.file_name() == file_name
+
+
+def test_to_json(feature: PartOfSpeechTagFrequenciesFeature, json: Json) -> None:
+    assert feature.to_json() == json
+
+
+def test_from_json(
+    json: Json,
+    part_of_speach_tags_counts: dict[str, int],
+    total_part_of_speach_tags_count: int,
+) -> None:
+    feature = PartOfSpeechTagFrequenciesFeature.from_json(data=json)
+    assert isinstance(feature, PartOfSpeechTagFrequenciesFeature)
+    assert feature.part_of_speach_tags_counts == part_of_speach_tags_counts
+    assert feature.total_part_of_speach_tags_count == total_part_of_speach_tags_count

--- a/tests/features/extractors/average/test_pos_tag_frequencies.py
+++ b/tests/features/extractors/average/test_pos_tag_frequencies.py
@@ -1,0 +1,21 @@
+from pytest import fixture
+
+from authorship_attribution._internal.features.extractors.average.pos_tag_frequencies import (
+    PartOfSpeechTagFrequenciesFeatureExtractor,
+)
+from authorship_attribution._internal.types.aliases import Text
+
+
+@fixture
+def text() -> Text:
+    return "This is a test text. Don't take it seriously."
+
+@fixture
+def extractor(text: Text) -> PartOfSpeechTagFrequenciesFeatureExtractor:
+    return PartOfSpeechTagFrequenciesFeatureExtractor(text)
+
+def test_part_of_speach_tags_counts(extractor: PartOfSpeechTagFrequenciesFeatureExtractor):
+    assert extractor.part_of_speach_tags_counts() == {'DT': 2, 'NN': 2, 'PRP': 1, 'RB': 2, 'VB': 1, 'VBP': 1, 'VBZ': 1}
+
+def test_total_part_of_speach_tags_count(extractor: PartOfSpeechTagFrequenciesFeatureExtractor):
+    assert extractor.total_part_of_speach_tags_count() == 10

--- a/tests/features/extractors/average/test_pos_tag_frequencies.py
+++ b/tests/features/extractors/average/test_pos_tag_frequencies.py
@@ -10,12 +10,27 @@ from authorship_attribution._internal.types.aliases import Text
 def text() -> Text:
     return "This is a test text. Don't take it seriously."
 
+
 @fixture
 def extractor(text: Text) -> PartOfSpeechTagFrequenciesFeatureExtractor:
     return PartOfSpeechTagFrequenciesFeatureExtractor(text)
 
-def test_part_of_speach_tags_counts(extractor: PartOfSpeechTagFrequenciesFeatureExtractor):
-    assert extractor.part_of_speach_tags_counts() == {'DT': 2, 'NN': 2, 'PRP': 1, 'RB': 2, 'VB': 1, 'VBP': 1, 'VBZ': 1}
 
-def test_total_part_of_speach_tags_count(extractor: PartOfSpeechTagFrequenciesFeatureExtractor):
+def test_part_of_speach_tags_counts(
+    extractor: PartOfSpeechTagFrequenciesFeatureExtractor,
+):
+    assert extractor.part_of_speach_tags_counts() == {
+        "DT": 2,
+        "NN": 2,
+        "PRP": 1,
+        "RB": 2,
+        "VB": 1,
+        "VBP": 1,
+        "VBZ": 1,
+    }
+
+
+def test_total_part_of_speach_tags_count(
+    extractor: PartOfSpeechTagFrequenciesFeatureExtractor,
+):
     assert extractor.total_part_of_speach_tags_count() == 10


### PR DESCRIPTION
### Description

```Markdown
How often different types of words (nouns, verbs, adjectives, adverbs, pronouns, prepositions, etc.) appear.

1. Calculate all part of speech tags for a text.
2. Count the amount of times each tag appears and divide each count by the total amount of tags.
```

### Todo

```Markdown
- [x] Implement the `PartofSpeechTagFrequenciesFeature` type.
- [x] Implement the `PartofSpeechTagFrequenciesFeatureExtractor` type.
```

### Definition Of Done

- [x] Add proper Issue metadata
- [x] Run Ruff from workspace root
- [x] Create unit tests for new code
- [x] Adjust unit tests for updated code
- [x] Remove unit tests for removed code
- [x] Add proper Pull Request metadata